### PR TITLE
Stop actions workflow running on forks

### DIFF
--- a/.github/workflows/minify-json.yml
+++ b/.github/workflows/minify-json.yml
@@ -15,6 +15,9 @@ on:
 
 jobs:
     minify-json:
+        # Only run this job for the main repository
+        if: github.repository == 'XengShi/multilingual-quotes-api'
+
         # Use latest Ubuntu runner
         runs-on: ubuntu-latest
 


### PR DESCRIPTION
fixes https://github.com/prem-k-r/multilingual-quotes-api/commit/7356e4aafdcfff2e32bce77e5e4bd0429475fca8


Workflow is falling here with error:
`
Permission to XengShi/multilingual-quotes-api.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/XengShi/multilingual-quotes-api/':
The requested URL returned error: 403
`

@XengShi, can you please check and give permission to github-actions[bot] if needed

https://github.com/XengShi/multilingual-quotes-api/settings/actions
scroll down, choose first option and click save 
![image](https://github.com/user-attachments/assets/1de300c3-e3ef-44ee-9e7b-c1c47c8034f0)
